### PR TITLE
AN-3665 Move metrica initialization to separate method

### DIFF
--- a/app/src/main/java/com/yurykorotin/analyticscomposite/AnalyticsComposite.kt
+++ b/app/src/main/java/com/yurykorotin/analyticscomposite/AnalyticsComposite.kt
@@ -1,9 +1,11 @@
 package com.yurykorotin.analyticscomposite
 
+import com.yurykorotin.analyticscomposite.components.AnalyticsComponent
 import com.yurykorotin.analyticscomposite.events.ecommerce.EcommerceBaseEvent
 import com.yurykorotin.analyticscomposite.events.AnalyticsBaseEvent
 
 abstract class AnalyticsComposite {
     abstract fun trackEvent(acBaseEvent: AnalyticsBaseEvent)
     abstract fun trackEcommerceEvent(ecommerceEvent: EcommerceBaseEvent)
+    abstract fun findAnalyticsComponentById(id: String): AnalyticsComponent?
 }

--- a/app/src/main/java/com/yurykorotin/analyticscomposite/BaseComposite.kt
+++ b/app/src/main/java/com/yurykorotin/analyticscomposite/BaseComposite.kt
@@ -20,6 +20,10 @@ class BaseComposite (
         }
     }
 
+    override fun findAnalyticsComponentById(id: String): AnalyticsComponent? {
+        return components.firstOrNull { it.id == id }
+    }
+
     class CompositeBuilder {
         private val components: MutableList<AnalyticsComponent> = mutableListOf()
 

--- a/app/src/main/java/com/yurykorotin/analyticscomposite/components/AmplitudeComponent.kt
+++ b/app/src/main/java/com/yurykorotin/analyticscomposite/components/AmplitudeComponent.kt
@@ -3,7 +3,7 @@ package com.yurykorotin.analyticscomposite.components
 import android.content.Context
 import com.yurykorotin.analyticscomposite.events.AnalyticsBaseEvent
 
-class AmplitudeComponent(context: Context) : AnalyticsComponent() {
+class AmplitudeComponent(context: Context, id: String) : AnalyticsComponent(id) {
     override fun trackEvent(acBaseEvent: AnalyticsBaseEvent) {
 
     }

--- a/app/src/main/java/com/yurykorotin/analyticscomposite/components/AnalyticsComponent.kt
+++ b/app/src/main/java/com/yurykorotin/analyticscomposite/components/AnalyticsComponent.kt
@@ -3,7 +3,7 @@ package com.yurykorotin.analyticscomposite.components
 import com.yurykorotin.analyticscomposite.events.ecommerce.EcommerceBaseEvent
 import com.yurykorotin.analyticscomposite.events.AnalyticsBaseEvent
 
-abstract class AnalyticsComponent {
+abstract class AnalyticsComponent(val id: String) {
     abstract fun trackEvent(acBaseEvent: AnalyticsBaseEvent)
     open fun trackECommerceEvent(ecommerceBaseEvent: EcommerceBaseEvent) = Unit
 }

--- a/app/src/main/java/com/yurykorotin/analyticscomposite/components/FirebaseComponent.kt
+++ b/app/src/main/java/com/yurykorotin/analyticscomposite/components/FirebaseComponent.kt
@@ -6,7 +6,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.yurykorotin.analyticscomposite.AnalyticsParams
 import com.yurykorotin.analyticscomposite.events.*
 
-class FirebaseComponent(context: Context) : AnalyticsComponent() {
+class FirebaseComponent(context: Context, id: String) : AnalyticsComponent(id) {
 
     private val firebaseService = FirebaseAnalytics.getInstance(context)
 

--- a/app/src/main/java/com/yurykorotin/analyticscomposite/components/appmetrica/AppMetricaComponent.kt
+++ b/app/src/main/java/com/yurykorotin/analyticscomposite/components/appmetrica/AppMetricaComponent.kt
@@ -13,20 +13,10 @@ import java.io.Serializable
 
 
 class AppMetricaComponent(
-    application: Application,
-    apiKey: String = ""
-) : AnalyticsComponent() {
-
-    init {
-        val config: YandexMetricaConfig = YandexMetricaConfig
-            .newConfigBuilder(apiKey)
-            .withLogs()
-           .build()
-
-        YandexMetrica.activate(application.applicationContext, config)
-        YandexMetrica.enableActivityAutoTracking(application)
-        YandexMetrica.setLocationTracking(false)
-    }
+    val application: Application,
+    val apiKey: String = "",
+    id: String
+) : AnalyticsComponent(id) {
 
     override fun trackEvent(acBaseEvent: AnalyticsBaseEvent) {
         if (acBaseEvent.key.isEmpty()) {
@@ -130,6 +120,17 @@ class AppMetricaComponent(
         val addedItem = ECommerceCartItem(ecommerceProduct, eCommercePrice, 1.0)
 
         return ECommerceEvent.addCartItemEvent(addedItem)
+    }
+
+    fun initializeMetrica() {
+        val config: YandexMetricaConfig = YandexMetricaConfig
+            .newConfigBuilder(apiKey)
+            .withLogs()
+            .build()
+
+        YandexMetrica.activate(application.applicationContext, config)
+        YandexMetrica.enableActivityAutoTracking(application)
+        YandexMetrica.setLocationTracking(false)
     }
 
 }


### PR DESCRIPTION
To call it initialization after Firebase initialization. Add ability to find AnalyticsComponent by id in BaseComposite to call initialization method for Yandex Metrica

resolves AN-3665